### PR TITLE
Fix input check

### DIFF
--- a/R/decontam.R
+++ b/R/decontam.R
@@ -161,7 +161,7 @@ setMethod("isContaminant", signature = c(seqtab = "ANY"),
   }
   if(do.freq) {
     if(is.null(conc)) stop("conc must be provided to perform frequency-based contaminant identification.")
-    if(!(is.numeric(conc) && all(conc>0))) stop("conc must be positive numeric.")
+    if(!(is.numeric(na.omit(conc)) && all(na.omit(conc)>0))) stop("conc must be positive numeric.")
     if(nrow(seqtab) != length(conc)) stop("The length of conc must match the number of samples (the rows of seqtab).")
     if(is.null(neg)) neg <- rep(FALSE, length(conc)) # Don't ignore any samples
   }


### PR DESCRIPTION
Hello!

I noticed that this input check fails if there are missing values. It leads to ambiguous error:
```

library(decontam)
st <- readRDS(system.file("extdata", "st.rds", package="decontam"))
conc <- c(6413, 3581.0, 5375, 4107, 4291, 4260, 4171, 2765, 33, NA)
isContaminant(st, conc=conc)
```

> Error in if (!(is.numeric(conc) && all(conc > 0))) stop("conc must be positive numeric.") : 
>   missing value where TRUE/FALSE needed

-Tuomas